### PR TITLE
transmission: add 'torrent-set' RPC call

### DIFF
--- a/transmission/optional.go
+++ b/transmission/optional.go
@@ -51,3 +51,15 @@ func OptWeekday(v Weekday) *Weekday {
 func OptEncryption(v Encryption) *Encryption {
 	return &v
 }
+
+// OptPriority is a helper routine that allocates new Priority to store v and
+// returns a pointer to it.
+func OptPriority(v Priority) *Priority {
+	return &v
+}
+
+// OptLimit is a helper routine that allocates new Limit to store v and returns
+// a pointer to it.
+func OptLimit(v Limit) *Limit {
+	return &v
+}

--- a/transmission/session_set.go
+++ b/transmission/session_set.go
@@ -64,10 +64,10 @@ type SetSessionReq struct {
 	QueueStalled *time.Duration `json:"-"`
 	// Indicates whether or not to consider idle torrents as stalled
 	QueueStalledEnabled *bool `json:"queue-stalled-enabled,omitempty"`
-	// The default upload ratio for torrents
-	UploadRatio *float64 `json:"seedRatioLimit,omitempty"`
+	// The default upload ratio limit for torrents
+	UploadRatioLimit *float64 `json:"seedRatioLimit,omitempty"`
 	// Indicates whether or not to consider upload ration
-	UploadRatioEnabled *bool `json:"seedRatioLimited,omitempty"`
+	UploadRatioLimitEnabled *bool `json:"seedRatioLimited,omitempty"`
 
 	// Indicates whether DHT is allowed for public torrents
 	DHTEnabled *bool `json:"dht-enabled,omitempty"`
@@ -155,9 +155,5 @@ func (c *Client) SetSession(ctx context.Context, req *SetSessionReq) error {
 		setSessionJSON.IdleSeedingLimit = OptDuration(*req.IdleSeedingLimit / time.Minute)
 	}
 
-	if err := c.callRPC(ctx, "session-set", &setSessionJSON, nil); err != nil {
-		return err
-	}
-
-	return nil
+	return c.callRPC(ctx, "session-set", &setSessionJSON, nil)
 }

--- a/transmission/session_set_test.go
+++ b/transmission/session_set_test.go
@@ -94,8 +94,8 @@ func TestSetSession(t *testing.T) {
 		UploadQueueLimitEnabled:   OptBool(true),
 		QueueStalled:              OptDuration(30 * time.Minute),
 		QueueStalledEnabled:       OptBool(true),
-		UploadRatio:               OptFloat64(2),
-		UploadRatioEnabled:        OptBool(true),
+		UploadRatioLimit:          OptFloat64(2),
+		UploadRatioLimitEnabled:   OptBool(true),
 
 		DHTEnabled: OptBool(true),
 		LPDEnabled: OptBool(true),

--- a/transmission/torrent_set.go
+++ b/transmission/torrent_set.go
@@ -1,0 +1,111 @@
+package transmission
+
+import (
+	"context"
+	"net/url"
+	"time"
+)
+
+// TrackerReplacement contains a replacement announce URL for a tracker.
+type TrackerReplacement struct {
+	ID          int
+	AnnounceURL *url.URL
+}
+
+// SetTorrentReq holds input for SetTorrent request.
+type SetTorrentReq struct {
+	// Torrent download rate limit (bytes/s)
+	DownloadRateLimit *int64 `json:"-"`
+	// Honor torrent download rate limit
+	DownloadRateLimitEnabled *bool `json:"downloadLimited,omitempty"`
+	// Torrent upload rate limit (bytes/s)
+	UploadRateLimit *int64 `json:"-"`
+	// Honor torrent upload rate limit
+	UploadRateLimitEnabled *bool `json:"uploadLimited,omitempty"`
+	// Whether to honor session download/upload limits or not
+	HonorSessionLimits *bool `json:"honorsSessionLimits,omitempty"`
+
+	// Torrent priority
+	Priority *Priority `json:"bandwidthPriority,omitempty"`
+	// An array of high priority file indicies (empty array means all
+	// files)
+	HighPriorityFiles []int `json:"priority-high"`
+	// An array of normal priority file indicies (empty array means all
+	// files)
+	NormalPriorityFiles []int `json:"priority-normal"`
+	// An array of low priority file indicies (empty array means all files)
+	LowPriorityFiles []int `json:"priority-low"`
+	// Position of this torrent in the queue
+	PositionInQueue *int `json:"queuePosition,omitempty"`
+
+	// Indicies of files to download (empty array means all files)
+	WantedFiles []int `json:"files-wanted"`
+	// Indicies of files to not download (empty array means all files)
+	UnwantedFiles []int `json:"files-unwanted"`
+
+	// Maximum number of peers
+	PeerLimit *int `json:"peer-limit,omitempty"`
+
+	// New location of the torrent contents
+	Location *string `json:"location,omitempty"`
+
+	// Stop torrent after given time of inactivity
+	IdleSeedingLimit *time.Duration `json:"-"`
+	// Which IdleSeedingLimit value to use
+	IdleSeedingLimitMode *Limit `json:"seedIdleMode,omitempty"`
+	// Stop seeding after reaching the given ratio
+	UploadRatioLimit *float64 `json:"seedRatioLimit,omitempty"`
+	// Which UploadRatioLimit value to use
+	UploadRatioLimitMode *Limit `json:"seedRatioMode,omitempty"`
+
+	// Add trackers with the given URIs to the torrent
+	TrackersToAdd []*url.URL `json:"-"`
+	// Remove trackers with the given ids from the torrent
+	TrackerToRemove []int `json:"trackerRemove,omitempty"`
+	// List of trackers with updated announcement URIs
+	TrackersToReplace []TrackerReplacement `json:"-"`
+}
+
+// SetTorrents modifies parameters for the torrents identified by ids.
+//
+// https://github.com/transmission/transmission/blob/46b3e6c8dae02531b1eb8907b51611fb9229b54a/extras/rpc-spec.txt#L105
+func (c *Client) SetTorrents(ctx context.Context, ids Identifier, req *SetTorrentReq) error {
+	uc := c.getUnitConversion()
+
+	var setTorrentsJSON = struct {
+		*SetTorrentReq
+		IDs               Identifier     `json:"ids,omitempty"`
+		DownloadRateLimit *int64         `json:"downloadLimit,omitempty"`
+		UploadRateLimit   *int64         `json:"uploadLimit,omitempty"`
+		IdleSeedingLimit  *time.Duration `json:"seedIdleLimit,omitempty"`
+		TrackersToAdd     []string       `json:"trackerAdd,omitempty"`
+		TrackersToReplace []interface{}  `json:"trackerReplace,omitempty"`
+	}{
+		SetTorrentReq: req,
+		IDs:           ids,
+	}
+	if req.DownloadRateLimit != nil {
+		setTorrentsJSON.DownloadRateLimit = OptInt64(*req.DownloadRateLimit / uc.speed)
+	}
+	if req.UploadRateLimit != nil {
+		setTorrentsJSON.UploadRateLimit = OptInt64(*req.UploadRateLimit / uc.speed)
+	}
+	if req.IdleSeedingLimit != nil {
+		setTorrentsJSON.IdleSeedingLimit = OptDuration(*req.IdleSeedingLimit / time.Minute)
+	}
+	if len(req.TrackersToAdd) > 0 {
+		setTorrentsJSON.TrackersToAdd = make([]string, len(req.TrackersToAdd))
+		for i, t := range req.TrackersToAdd {
+			setTorrentsJSON.TrackersToAdd[i] = t.String()
+		}
+	}
+	if len(req.TrackersToReplace) > 0 {
+		setTorrentsJSON.TrackersToReplace = make([]interface{}, len(req.TrackersToReplace)*2)
+		for i, t := range req.TrackersToReplace {
+			setTorrentsJSON.TrackersToReplace[i*2] = t.ID
+			setTorrentsJSON.TrackersToReplace[i*2+1] = t.AnnounceURL.String()
+		}
+	}
+
+	return c.callRPC(ctx, "torrent-set", &setTorrentsJSON, nil)
+}

--- a/transmission/torrent_set_test.go
+++ b/transmission/torrent_set_test.go
@@ -1,0 +1,96 @@
+package transmission
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestSetTorrent(t *testing.T) {
+	parseURL := func(t *testing.T, str string) *url.URL {
+		t.Helper()
+
+		u, err := url.Parse(str)
+		if err != nil {
+			t.Fatalf("failed to parse URL %q: %v", str, err)
+		}
+		return u
+	}
+
+	client, handle, teardown := setup(t)
+	defer teardown()
+
+	handle(func(w http.ResponseWriter, r *http.Request) {
+		testBody(t, r, `{
+			"method": "torrent-set",
+			"arguments": {
+			  "downloadLimited": true,
+			  "uploadLimited": true,
+			  "honorsSessionLimits": true,
+                          "bandwidthPriority": -1,
+			  "priority-high": [1, 4, 7],
+			  "priority-normal": [2, 5, 8],
+			  "priority-low": [3, 6, 9],
+			  "queuePosition": 3,
+			  "files-wanted": [1, 2, 3, 4, 5, 6, 7, 8, 9],
+			  "files-unwanted": [10, 11],
+			  "peer-limit": 100,
+			  "location": "/home/transmission/new",
+			  "seedIdleMode": 0,
+			  "seedRatioLimit": 2.45,
+			  "seedRatioMode": 1,
+			  "trackerRemove": [1, 2, 3],
+			  "ids": [2, "abcde"],
+                          "downloadLimit": 10240,
+			  "uploadLimit": 10240,
+			  "seedIdleLimit": 60,
+			  "trackerAdd": ["http://retracker.local:80", "http://bt2.t-ru.org:80"],
+			  "trackerReplace": [1, "http://retracker.local:80", 2, "http://bt2.t-ru.org:80"]
+			}
+		  }`)
+
+		fmt.Fprintf(w, `{"result":"success"}`)
+	})
+
+	err := client.SetTorrents(context.Background(), IDs(ID(2), Hash("abcde")), &SetTorrentReq{
+		DownloadRateLimit:        OptInt64(10240000),
+		DownloadRateLimitEnabled: OptBool(true),
+		UploadRateLimit:          OptInt64(10240000),
+		UploadRateLimitEnabled:   OptBool(true),
+		HonorSessionLimits:       OptBool(true),
+
+		Priority:            OptPriority(PriorityLow),
+		HighPriorityFiles:   []int{1, 4, 7},
+		NormalPriorityFiles: []int{2, 5, 8},
+		LowPriorityFiles:    []int{3, 6, 9},
+		PositionInQueue:     OptInt(3),
+
+		WantedFiles:   []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		UnwantedFiles: []int{10, 11},
+
+		PeerLimit: OptInt(100),
+
+		Location: OptString("/home/transmission/new"),
+
+		IdleSeedingLimit:     OptDuration(60 * time.Minute),
+		IdleSeedingLimitMode: OptLimit(LimitGlobal),
+		UploadRatioLimit:     OptFloat64(2.45),
+		UploadRatioLimitMode: OptLimit(LimitLocal),
+
+		TrackersToAdd: []*url.URL{
+			parseURL(t, "http://retracker.local:80"),
+			parseURL(t, "http://bt2.t-ru.org:80"),
+		},
+		TrackerToRemove: []int{1, 2, 3},
+		TrackersToReplace: []TrackerReplacement{
+			{ID: 1, AnnounceURL: parseURL(t, "http://retracker.local:80")},
+			{ID: 2, AnnounceURL: parseURL(t, "http://bt2.t-ru.org:80")},
+		},
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/transmission/types.go
+++ b/transmission/types.go
@@ -93,3 +93,21 @@ func (e *Encryption) UnmarshalJSON(data []byte) error {
 
 	return fmt.Errorf("unsupported Encryption value %q", enc)
 }
+
+// Priority indicates torrent or file priority.
+type Priority int
+
+const (
+	PriorityLow    Priority = -1
+	PriorityNormal Priority = 0
+	PriorityHigh   Priority = 1
+)
+
+// Limit controls whether a particular torrent follows global limits or not.
+type Limit int
+
+const (
+	LimitGlobal    Limit = 0 // Honor global limit
+	LimitLocal     Limit = 1 // Honor local torrent limit
+	LimitUnlimited Limit = 2 // Don't honor any limit
+)


### PR DESCRIPTION
Allows to modify parameters of existing torrents.